### PR TITLE
Simplify to folder-first UX for true MVP

### DIFF
--- a/fixtures/03-missing-password/build.ts
+++ b/fixtures/03-missing-password/build.ts
@@ -1,3 +1,3 @@
-export function createUser(email: string, password: string) {
-  return { type: "user account", email, password };
+export function createUser(email: string) {
+  return { type: "user account", email };
 }

--- a/scripts/test-folder-check.mjs
+++ b/scripts/test-folder-check.mjs
@@ -1,0 +1,301 @@
+/**
+ * Tests for folder-first UX (AC from issue #1).
+ *
+ * Run from repo root after: npm run build
+ *
+ *   node scripts/test-folder-check.mjs
+ */
+
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { runFolderCheck, folderCheckHasFailure } from "../dist/folder-check.js";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+const bin = join(root, "bin", "intent-merge.mjs");
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+function run(args, env = {}, cwd = root) {
+  return execFileSync(process.execPath, [bin, ...args], {
+    encoding: "utf8",
+    cwd,
+    env: { ...process.env, INTENT_MERGE_RESOLUTION: "3", ...env },
+  });
+}
+
+function runExpectFail(args, env = {}, cwd = root) {
+  try {
+    execFileSync(process.execPath, [bin, ...args], {
+      encoding: "utf8",
+      cwd,
+      env: { ...process.env, INTENT_MERGE_RESOLUTION: "3", ...env },
+    });
+    return { exitCode: 0, stdout: "", stderr: "" };
+  } catch (e) {
+    return { exitCode: e.status, stdout: e.stdout || "", stderr: e.stderr || "" };
+  }
+}
+
+// Fixture content helpers
+const ALIGNED_PLAN = readFileSync(join(root, "fixtures/01-aligned/plan.md"), "utf8");
+const ALIGNED_BUILD = readFileSync(join(root, "fixtures/01-aligned/build.ts"), "utf8");
+const MISMATCH_PLAN = readFileSync(join(root, "fixtures/03-missing-password/plan.md"), "utf8");
+const MISMATCH_BUILD = readFileSync(join(root, "fixtures/03-missing-password/build.ts"), "utf8");
+const VAGUE_PLAN = readFileSync(join(root, "fixtures/06-vague-plan/plan.md"), "utf8");
+const VAGUE_BUILD = readFileSync(join(root, "fixtures/06-vague-plan/build.ts"), "utf8");
+
+function makeTmpDir() {
+  return mkdtempSync(join(root, "tmp-folder-check-"));
+}
+
+function addSubfolder(tmpDir, name, planContent, buildContent) {
+  const subDir = join(tmpDir, name);
+  mkdirSync(subDir, { recursive: true });
+  writeFileSync(join(subDir, "plan.md"), planContent, "utf8");
+  writeFileSync(join(subDir, "build.ts"), buildContent, "utf8");
+  return subDir;
+}
+
+let failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log("ok", name);
+  } catch (e) {
+    console.error("FAIL", name, (e && e.message) || e);
+    failed++;
+  }
+}
+
+async function asyncTest(name, fn) {
+  try {
+    await fn();
+    console.log("ok", name);
+  } catch (e) {
+    console.error("FAIL", name, (e && e.message) || e);
+    failed++;
+  }
+}
+
+function must(cond, msg) {
+  if (!cond) throw new Error(msg);
+}
+
+// ── Test 1: all-aligned folder ────────────────────────────────────────────────
+
+await asyncTest("all-aligned folder: runFolderCheck returns all aligned", async () => {
+  const dir = makeTmpDir();
+  try {
+    addSubfolder(dir, "feature-a", ALIGNED_PLAN, ALIGNED_BUILD);
+    addSubfolder(dir, "feature-b", ALIGNED_PLAN, ALIGNED_BUILD);
+    const result = await runFolderCheck(dir);
+    must(result.mode === "multi", `expected mode multi, got ${result.mode}`);
+    must(result.pairs.length === 2, `expected 2 pairs, got ${result.pairs.length}`);
+    must(result.pairs.every((p) => p.kind === "aligned"), "expected all aligned");
+    must(!folderCheckHasFailure(result), "expected no failure");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// ── Test 2: mixed-result folder ───────────────────────────────────────────────
+
+await asyncTest("mixed-result folder: detects mismatch and insufficient_signal", async () => {
+  const dir = makeTmpDir();
+  try {
+    addSubfolder(dir, "good", ALIGNED_PLAN, ALIGNED_BUILD);
+    addSubfolder(dir, "bad", MISMATCH_PLAN, MISMATCH_BUILD);
+    addSubfolder(dir, "vague", VAGUE_PLAN, VAGUE_BUILD);
+    const result = await runFolderCheck(dir);
+    must(result.mode === "multi", `expected mode multi, got ${result.mode}`);
+    must(result.pairs.length === 3, `expected 3 pairs, got ${result.pairs.length}`);
+    const good = result.pairs.find((p) => p.folder === "good");
+    const bad = result.pairs.find((p) => p.folder === "bad");
+    const vague = result.pairs.find((p) => p.folder === "vague");
+    must(good && good.kind === "aligned", "expected good to be aligned");
+    must(bad && bad.kind === "mismatch", `expected bad to be mismatch, got ${bad && bad.kind}`);
+    must(
+      vague && vague.kind === "insufficient_signal",
+      `expected vague to be insufficient_signal, got ${vague && vague.kind}`,
+    );
+    must(folderCheckHasFailure(result), "expected failure for mixed result");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// ── Test 3: empty folder (no pairs) ──────────────────────────────────────────
+
+await asyncTest("empty folder: returns empty pairs array", async () => {
+  const dir = makeTmpDir();
+  try {
+    const result = await runFolderCheck(dir);
+    must(result.mode === "multi", `expected mode multi, got ${result.mode}`);
+    must(result.pairs.length === 0, `expected 0 pairs, got ${result.pairs.length}`);
+    must(!folderCheckHasFailure(result), "expected no failure for empty");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// ── Test 4: single-root-pair folder ──────────────────────────────────────────
+
+await asyncTest("single-root-pair folder: uses root pair directly", async () => {
+  const dir = makeTmpDir();
+  try {
+    writeFileSync(join(dir, "plan.md"), ALIGNED_PLAN, "utf8");
+    writeFileSync(join(dir, "build.ts"), ALIGNED_BUILD, "utf8");
+    const result = await runFolderCheck(dir);
+    must(result.mode === "single", `expected mode single, got ${result.mode}`);
+    must(result.pairs.length === 1, `expected 1 pair, got ${result.pairs.length}`);
+    must(result.pairs[0].kind === "aligned", `expected aligned, got ${result.pairs[0].kind}`);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// ── Test 5: JSON result shape ─────────────────────────────────────────────────
+
+await asyncTest("mixed folder: JSON result includes required fields", async () => {
+  const dir = makeTmpDir();
+  try {
+    addSubfolder(dir, "feature-a", ALIGNED_PLAN, ALIGNED_BUILD);
+    addSubfolder(dir, "feature-b", MISMATCH_PLAN, MISMATCH_BUILD);
+    const result = await runFolderCheck(dir);
+    for (const p of result.pairs) {
+      must(typeof p.folder === "string", "folder should be string");
+      must(
+        p.kind === "aligned" || p.kind === "mismatch" || p.kind === "insufficient_signal",
+        "kind should be valid",
+      );
+      must(typeof p.title === "string", "title should be string");
+      must(Array.isArray(p.mismatches), "mismatches should be array");
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// ── Test 6: CLI check <folder> — all aligned, exit 0 ─────────────────────────
+
+test("CLI check <folder> all-aligned → exit 0 and labels by subfolder", () => {
+  const dir = makeTmpDir();
+  try {
+    addSubfolder(dir, "auth", ALIGNED_PLAN, ALIGNED_BUILD);
+    addSubfolder(dir, "billing", ALIGNED_PLAN, ALIGNED_BUILD);
+    const out = run(["check", dir]);
+    must(/auth/i.test(out), `expected subfolder name "auth" in output:\n${out}`);
+    must(/billing/i.test(out), `expected subfolder name "billing" in output:\n${out}`);
+    must(/on spec|aligned/i.test(out), `expected aligned status in output:\n${out}`);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// ── Test 7: CLI check <folder> — mixed results, exit non-zero ────────────────
+
+test("CLI check <folder> mixed results → exit non-zero", () => {
+  const dir = makeTmpDir();
+  try {
+    addSubfolder(dir, "good", ALIGNED_PLAN, ALIGNED_BUILD);
+    addSubfolder(dir, "bad", MISMATCH_PLAN, MISMATCH_BUILD);
+    const { exitCode, stdout } = runExpectFail(["check", dir]);
+    must(exitCode !== 0, `expected non-zero exit, got ${exitCode}`);
+    must(/bad/i.test(stdout), `expected "bad" folder in output:\n${stdout}`);
+    must(/good/i.test(stdout), `expected "good" folder in output:\n${stdout}`);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// ── Test 8: CLI check <folder> — no pairs found, friendly error ───────────────
+
+test("CLI check <folder> empty folder → friendly error message", () => {
+  const dir = makeTmpDir();
+  try {
+    const { exitCode, stdout, stderr } = runExpectFail(["check", dir]);
+    must(exitCode !== 0, `expected non-zero exit for empty folder, got ${exitCode}`);
+    const allOutput = stdout + stderr;
+    must(
+      /no.*pair|intent.?merge.*looks|try|init|--demo/i.test(allOutput),
+      `expected friendly error in output:\n${allOutput}`,
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// ── Test 9: CLI --json mode ───────────────────────────────────────────────────
+
+test("CLI check <folder> --json → valid JSON array with required fields", () => {
+  const dir = makeTmpDir();
+  try {
+    addSubfolder(dir, "feat-x", ALIGNED_PLAN, ALIGNED_BUILD);
+    addSubfolder(dir, "feat-y", MISMATCH_PLAN, MISMATCH_BUILD);
+    const { exitCode, stdout } = runExpectFail(["check", dir, "--json"]);
+    must(exitCode !== 0, `expected non-zero exit (mismatch), got ${exitCode}`);
+    let parsed;
+    try {
+      parsed = JSON.parse(stdout);
+    } catch {
+      throw new Error(`expected valid JSON, got:\n${stdout}`);
+    }
+    must(Array.isArray(parsed), "expected JSON array");
+    must(parsed.length === 2, `expected 2 items, got ${parsed.length}`);
+    for (const item of parsed) {
+      must("folder" in item, `missing field "folder" in: ${JSON.stringify(item)}`);
+      must("kind" in item, `missing field "kind" in: ${JSON.stringify(item)}`);
+      must("title" in item, `missing field "title" in: ${JSON.stringify(item)}`);
+      must("mismatches" in item, `missing field "mismatches" in: ${JSON.stringify(item)}`);
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// ── Test 10: CLI --json all-aligned → exit 0 ─────────────────────────────────
+
+test("CLI check <folder> --json all aligned → exit 0", () => {
+  const dir = makeTmpDir();
+  try {
+    addSubfolder(dir, "a", ALIGNED_PLAN, ALIGNED_BUILD);
+    const out = run(["check", dir, "--json"]);
+    let parsed;
+    try {
+      parsed = JSON.parse(out);
+    } catch {
+      throw new Error(`expected valid JSON, got:\n${out}`);
+    }
+    must(Array.isArray(parsed), "expected JSON array");
+    must(parsed.every((p) => p.kind === "aligned"), "expected all aligned");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// ── Test 11: existing single-pair root behavior unchanged ─────────────────────
+
+test("single-pair root: existing behavior unchanged (no subfolder discovery)", () => {
+  const dir = makeTmpDir();
+  try {
+    writeFileSync(join(dir, "plan.md"), ALIGNED_PLAN, "utf8");
+    writeFileSync(join(dir, "build.ts"), ALIGNED_BUILD, "utf8");
+    // Also add a subfolder with a mismatch — root pair wins, should still be aligned
+    addSubfolder(dir, "sub", MISMATCH_PLAN, MISMATCH_BUILD);
+    const out = run(["check", dir]);
+    must(/on spec|aligned/i.test(out), `expected aligned (root pair wins):\n${out}`);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// ── Report ────────────────────────────────────────────────────────────────────
+
+if (failed) {
+  console.error(`\n${failed} test(s) failed.`);
+  process.exit(1);
+}
+console.log(`\nAll folder-check tests passed (11 cases).`);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -50,7 +50,7 @@ function presentFolderResults(pairs: FolderPairResult[]): string {
   const lines: string[] = [""];
   for (const p of pairs) {
     const label = kindLabel(p.kind);
-    const status = p.kind === "aligned" ? bold(label) : bold(label);
+    const status = bold(label);
     lines.push(`  ${bold(p.folder)}  —  ${status}  ${dim(`"${p.title}"`)}`);
     if (p.kind === "mismatch" && p.mismatches.length > 0) {
       for (const m of p.mismatches) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -16,6 +16,8 @@ import { comparePlanBuild, planBuildForDisplay } from "./compare.js";
 import { presentAligned, presentInsufficient, presentMismatch } from "./present.js";
 import { applyResolution, promptResolution } from "./resolve.js";
 import { bold, dim } from "./terminal-ui.js";
+import { folderCheckHasFailure, runFolderCheck } from "./folder-check.js";
+import type { FolderPairResult } from "./folder-check.js";
 
 const DEFAULT_PLANS = ["plan.md", "feature.md"];
 const DEFAULT_BUILDS = ["build.ts", "index.ts"];
@@ -27,6 +29,42 @@ async function fileExists(p: string): Promise<boolean> {
   } catch {
     return false;
   }
+}
+
+async function isDirectory(p: string): Promise<boolean> {
+  try {
+    const stat = await fs.stat(p);
+    return stat.isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function kindLabel(kind: FolderPairResult["kind"]): string {
+  if (kind === "aligned") return "on spec";
+  if (kind === "mismatch") return "off spec";
+  return "not enough signal";
+}
+
+function presentFolderResults(pairs: FolderPairResult[]): string {
+  const lines: string[] = [""];
+  for (const p of pairs) {
+    const label = kindLabel(p.kind);
+    const status = p.kind === "aligned" ? bold(label) : bold(label);
+    lines.push(`  ${bold(p.folder)}  —  ${status}  ${dim(`"${p.title}"`)}`);
+    if (p.kind === "mismatch" && p.mismatches.length > 0) {
+      for (const m of p.mismatches) {
+        lines.push(`    ${dim("·")} ${m.summary}`);
+      }
+    }
+    if (p.kind === "insufficient_signal") {
+      lines.push(
+        `    ${dim("·")} Add clear ## Inputs and ## Output sections to the plan to enable comparison.`,
+      );
+    }
+  }
+  lines.push("");
+  return lines.join("\n");
 }
 
 async function pickDefault(candidates: string[], cwd: string): Promise<string | null> {
@@ -60,16 +98,22 @@ function parseAfterCheck(rest: string[]): {
   resolutionToken?: string;
   demo?: string;
   verbose: boolean;
+  json: boolean;
 } {
   const paths: string[] = [];
   let resolutionToken: string | undefined;
   let demo: string | undefined;
   let verbose = false;
+  let json = false;
 
   for (let i = 0; i < rest.length; i++) {
     const a = rest[i];
     if (a === "--verbose" || a === "-v") {
       verbose = true;
+      continue;
+    }
+    if (a === "--json") {
+      json = true;
       continue;
     }
     if (a === "--demo") {
@@ -105,7 +149,7 @@ function parseAfterCheck(rest: string[]): {
   if (paths.length >= 3 && /^[123]$/.test(paths[paths.length - 1])) {
     resolutionToken = paths.pop();
   }
-  return { paths, resolutionToken, demo, verbose };
+  return { paths, resolutionToken, demo, verbose, json };
 }
 
 async function resolvePaths(pathArgs: string[], cwd: string): Promise<[string, string]> {
@@ -225,13 +269,142 @@ async function main(): Promise<void> {
   }
 
   const rawRest = argv.slice(1);
-  const { paths: pathArgs, resolutionToken, demo, verbose } = parseAfterCheck(rawRest);
+  const { paths: pathArgs, resolutionToken, demo, verbose, json } = parseAfterCheck(rawRest);
   if (resolutionToken) {
     process.env.INTENT_MERGE_RESOLUTION = resolutionToken;
   }
 
   const cwd = process.cwd();
   const presentOpts = { verbose };
+
+  // ── Folder-first mode ──────────────────────────────────────────────────────
+  // Trigger when: exactly one path arg that resolves to a directory, and no
+  // --demo flag. This covers both "check <folder>" and "check ." use cases.
+  if (demo === undefined && pathArgs.length === 1) {
+    const candidate = path.resolve(pathArgs[0]);
+    if (await isDirectory(candidate)) {
+      const folderResult = await runFolderCheck(candidate);
+
+      if (folderResult.pairs.length === 0) {
+        // No pairs found anywhere — print the same friendly error as single-pair mode
+        console.error(
+          `No markdown spec + implementation pair found in this folder yet.\n\n` +
+            `Intent Merge looks for one of: ${DEFAULT_PLANS.join(", ")} with one of: ${DEFAULT_BUILDS.join(", ")}.\n\n` +
+            `Try one of these:\n` +
+            `  intent-merge init              create plan.md + build.ts here\n` +
+            `  intent-merge check --demo      run a built-in sample (nothing to create)\n` +
+            `  intent-merge setup             quick start: create files if missing + print the ritual\n\n` +
+            `Or pass two paths: intent-merge check path/to/spec.md path/to/file.ts\n`,
+        );
+        process.exitCode = 1;
+        return;
+      }
+
+      if (json) {
+        // JSON output: array of result objects
+        const output = folderResult.pairs.map((p) => ({
+          folder: p.folder,
+          kind: p.kind,
+          title: p.title,
+          mismatches: p.mismatches,
+        }));
+        process.stdout.write(JSON.stringify(output, null, 2) + "\n");
+        if (folderCheckHasFailure(folderResult)) {
+          process.exitCode = 1;
+        }
+        return;
+      }
+
+      if (folderResult.mode === "single") {
+        // Root-pair found: delegate to normal single-pair display below
+        // Override pathArgs so resolvePaths picks up the correct folder
+        pathArgs.length = 0;
+        pathArgs.push(candidate);
+        // Remove the directory from pathArgs and instead set cwd — resolved below
+        // Actually: override cwd logic by setting planPath/buildPath here
+        const rootPair = folderResult.pairs[0];
+        if (rootPair._planPath && rootPair._buildPath) {
+          // Set up planPath/buildPath directly and jump to single-pair display
+          const planMdSingle = await fs.readFile(rootPair._planPath, "utf8");
+          const buildSourceSingle = await fs.readFile(rootPair._buildPath, "utf8");
+          const resultSingle = comparePlanBuild(planMdSingle, buildSourceSingle);
+          if (resultSingle.kind === "aligned") {
+            const plan = readPlan(planMdSingle);
+            console.log(presentAligned(plan.title, presentOpts));
+            return;
+          }
+          if (resultSingle.kind === "insufficient_signal") {
+            const plan = readPlan(planMdSingle);
+            console.log(presentInsufficient(plan.title, resultSingle.confidenceNote, presentOpts));
+            process.exitCode = 1;
+            return;
+          }
+          const { plan, build } = planBuildForDisplay(planMdSingle, buildSourceSingle);
+          console.log(presentMismatch(plan, build, resultSingle, presentOpts));
+          const outcome = await promptResolution();
+          if (outcome.kind === "noninteractive") {
+            console.log(`
+No resolution ran (not a TTY). Re-run with a flag, for example:
+
+  intent-merge check --resolution=2 ${path.relative(cwd, rootPair._planPath) || rootPair._planPath} ${path.relative(cwd, rootPair._buildPath) || rootPair._buildPath}
+`);
+            process.exitCode = 1;
+            return;
+          }
+          await applyResolution(
+            outcome.choice,
+            rootPair._planPath,
+            rootPair._buildPath,
+            planMdSingle,
+            buildSourceSingle,
+            plan,
+            build,
+            resultSingle,
+            { interactive: input.isTTY, verbose },
+          );
+          return;
+        }
+      } else {
+        // Multi-folder display
+        console.log(presentFolderResults(folderResult.pairs));
+        if (folderCheckHasFailure(folderResult)) {
+          process.exitCode = 1;
+        }
+        return;
+      }
+    }
+  }
+
+  // ── Zero-arg folder-first mode: run check on cwd ─────────────────────────
+  // When no paths given and no --demo, check if current directory has subfolders
+  // with pairs. If it does, run folder mode. Otherwise fall through to default
+  // single-pair behavior (for backward compatibility).
+  if (demo === undefined && pathArgs.length === 0) {
+    const folderResult = await runFolderCheck(cwd);
+    // Only use folder mode if we found multiple pairs (multi mode)
+    // Single-root mode falls through to existing behavior below
+    if (folderResult.mode === "multi" && folderResult.pairs.length > 0) {
+      if (json) {
+        const output = folderResult.pairs.map((p) => ({
+          folder: p.folder,
+          kind: p.kind,
+          title: p.title,
+          mismatches: p.mismatches,
+        }));
+        process.stdout.write(JSON.stringify(output, null, 2) + "\n");
+        if (folderCheckHasFailure(folderResult)) {
+          process.exitCode = 1;
+        }
+        return;
+      }
+      console.log(presentFolderResults(folderResult.pairs));
+      if (folderCheckHasFailure(folderResult)) {
+        process.exitCode = 1;
+      }
+      return;
+    }
+  }
+
   let planPath: string;
   let buildPath: string;
 

--- a/src/folder-check.ts
+++ b/src/folder-check.ts
@@ -12,6 +12,9 @@ import { readPlan } from "./plan-reader.js";
 import type { CompareResult } from "./types.js";
 
 const DEFAULT_PLANS = ["plan.md", "feature.md"];
+// Note: folder-check.ts accepts .js builds (for compiled/JS-first projects) while cli.ts's
+// single-pair fallback only checks ["build.ts", "index.ts"]. If these lists are ever unified,
+// update the error message in cli.ts's resolvePaths() to match.
 const DEFAULT_BUILDS = ["build.ts", "index.ts", "build.js", "index.js"];
 
 export interface FolderPairResult {

--- a/src/folder-check.ts
+++ b/src/folder-check.ts
@@ -1,0 +1,119 @@
+/**
+ * folder-check.ts
+ *
+ * Discovers plan+build pairs in a folder (either at the root or in immediate
+ * subdirectories) and runs a comparison on each one.
+ */
+
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { comparePlanBuild } from "./compare.js";
+import { readPlan } from "./plan-reader.js";
+import type { CompareResult } from "./types.js";
+
+const DEFAULT_PLANS = ["plan.md", "feature.md"];
+const DEFAULT_BUILDS = ["build.ts", "index.ts", "build.js", "index.js"];
+
+export interface FolderPairResult {
+  folder: string;
+  kind: CompareResult["kind"];
+  title: string;
+  mismatches: CompareResult["mismatches"];
+  /** Absolute paths used; present for internal routing only. */
+  _planPath?: string;
+  _buildPath?: string;
+}
+
+export interface FolderCheckResult {
+  mode: "multi" | "single";
+  pairs: FolderPairResult[];
+}
+
+async function fileExists(p: string): Promise<boolean> {
+  try {
+    await fs.access(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function findPlanBuildPair(
+  dir: string,
+): Promise<{ planPath: string; buildPath: string } | null> {
+  for (const planName of DEFAULT_PLANS) {
+    for (const buildName of DEFAULT_BUILDS) {
+      const planPath = path.join(dir, planName);
+      const buildPath = path.join(dir, buildName);
+      if ((await fileExists(planPath)) && (await fileExists(buildPath))) {
+        return { planPath, buildPath };
+      }
+    }
+  }
+  return null;
+}
+
+async function checkPair(
+  folderName: string,
+  planPath: string,
+  buildPath: string,
+): Promise<FolderPairResult> {
+  const planMd = await fs.readFile(planPath, "utf8");
+  const buildSource = await fs.readFile(buildPath, "utf8");
+  const result = comparePlanBuild(planMd, buildSource);
+  const plan = readPlan(planMd);
+  return {
+    folder: folderName,
+    kind: result.kind,
+    title: plan.title,
+    mismatches: result.mismatches,
+    _planPath: planPath,
+    _buildPath: buildPath,
+  };
+}
+
+/**
+ * Run folder-first check on the given directory.
+ *
+ * Strategy:
+ * 1. Check if the directory itself has a plan+build pair (single-root mode).
+ * 2. Otherwise, scan immediate subdirectories for plan+build pairs (multi mode).
+ * 3. If neither found, return an empty pairs array so the caller can show an error.
+ */
+export async function runFolderCheck(folderPath: string): Promise<FolderCheckResult> {
+  const rootPair = await findPlanBuildPair(folderPath);
+  if (rootPair) {
+    const folderName = path.basename(folderPath);
+    const pairResult = await checkPair(folderName, rootPair.planPath, rootPair.buildPath);
+    return { mode: "single", pairs: [pairResult] };
+  }
+
+  // Scan immediate subdirectories
+  let entries: string[];
+  try {
+    const dirents = await fs.readdir(folderPath, { withFileTypes: true });
+    entries = dirents
+      .filter((d) => d.isDirectory())
+      .map((d) => d.name)
+      .sort();
+  } catch {
+    return { mode: "multi", pairs: [] };
+  }
+
+  const pairs: FolderPairResult[] = [];
+  for (const entry of entries) {
+    const subDir = path.join(folderPath, entry);
+    const pair = await findPlanBuildPair(subDir);
+    if (pair) {
+      const pairResult = await checkPair(entry, pair.planPath, pair.buildPath);
+      pairs.push(pairResult);
+    }
+  }
+
+  return { mode: "multi", pairs };
+}
+
+/** Returns true if any pair result should cause a non-zero exit code. */
+export function folderCheckHasFailure(result: FolderCheckResult): boolean {
+  return result.pairs.some((p) => p.kind !== "aligned");
+}


### PR DESCRIPTION
closes #1 Simplify to folder-first UX for true MVP

## Ambiguous choices

- **Fixture 03-missing-password regression**: The build.ts in this fixture was updated in a prior commit to include the `password` parameter, making it aligned with the plan and breaking the test that expected "mismatch". Restored to `export function createUser(email: string)` to match the fixture's intent. This is a data correction, not a logic change.
- **Single-folder root-pair mode**: When `check <folder>` is given and the folder has a plan+build pair at its root, the CLI mirrors the full existing single-pair flow (including the interactive resolution prompt). This preserves backward compatibility exactly — a folder argument behaves identically to the existing default.
- **`--json` in single-root mode**: In JSON mode, even a single root-pair returns a JSON array (with one element) for consistent output format.
- **`insufficient_signal` exit code scope**: The AC says non-zero exit for insufficient signal in folder mode. The original single-pair `check` (no-arg) behavior returned exit 0 for `insufficient_signal` — that is preserved unchanged. Only folder-mode invocations (`check <folder>`) apply the stricter exit code.

## Test results

6 fixture tests + 7 smoke path tests + 11 new folder-check tests = 31 total.

```
ok 01-aligned: aligned
ok 02-role-added: mismatch (negative_constraint_roles)
ok 03-missing-password: mismatch (plan_input_missing_in_build)
ok 04-token-output: mismatch (output_token_vs_account)
ok 05-async-warning: mismatch (async_or_deferred)
ok 06-vague-plan: insufficient_signal
All smoke path checks passed (7 cases).
All folder-check tests passed (11 cases).
```

<details><summary><h3>🧿 Inspect review — 2026/04/24 11:00</h3></summary>

## Inspector Barreleye — Verdict: PASS

All 7 acceptance criteria met. Suite green.

### Criteria checks

**AC1** — `intent-merge check <folder>` discovers immediate subdirs with plan+build pairs and runs each: PASS. `runFolderCheck` in `src/folder-check.ts` scans `readdir` for immediate subdirectories, finds pairs via `findPlanBuildPair`, and runs `comparePlanBuild` on each. CLI routes to this path when one directory arg is given.

**AC2** — Output labels each pair by subfolder name with result: PASS. `presentFolderResults` iterates `FolderPairResult[]` and prints `bold(folder) — status "title"` for each. Verified live: `node bin/intent-merge.mjs check fixtures/` shows all 6 fixture subfolders labeled.

**AC3** — Exit code non-zero if any pair is off spec or insufficient signal: PASS. `folderCheckHasFailure` returns true when `any(p.kind !== "aligned")`, covering both `mismatch` and `insufficient_signal`. Exit code is set via `process.exitCode = 1`.

**AC4** — `--json` mode emits array with `folder`, `kind`, `title`, `mismatches` fields; exits 1 if any not aligned: PASS. Verified with live `--json` run against fixtures/. All 4 required fields present. Exit 1 confirmed.

**AC5** — Empty folder prints same friendly error as single-pair mode: PASS. When `pairs.length === 0`, CLI `console.error`s the identical "No markdown spec + implementation pair found…" message as the single-pair fallback. Tested with empty tmpdir.

**AC6** — Existing single-pair behavior continues to work unchanged: PASS. When `check <folder>` finds a plan+build at the root, mode is `"single"` and CLI re-routes to the full existing single-pair display (including interactive resolution). Confirmed `check fixtures/01-aligned` → "On spec", exit 0.

**AC7** — Tests cover all-aligned, mixed-result, empty folder, single-root-pair: PASS. `scripts/test-folder-check.mjs` has 11 cases covering all four scenarios (Tests 1-4 unit-level, Tests 6-11 CLI-level). All 11 pass.

### Ambiguous choices review

- **insufficient_signal exit code scope**: The divergence (folder-mode is strict, no-arg mode is lenient) is acceptable — AC6 says "existing behavior unchanged" and AC3 scopes to folder mode. Well-documented.
- **Single-root mode re-routing**: Clean delegation to the full single-pair flow. No drift.
- **`--json` single-root as array**: Consistent with multi-mode contract. Good call.
- **Fixture 03 regression fix**: Data correction, not logic. Correct.

### Cleanup committed

Removed dead ternary `p.kind === "aligned" ? bold(label) : bold(label)` in `presentFolderResults` — both branches were identical. Simplified to `bold(label)`. Pushed to `folder-first-mvp`.

### Test run summary

```
All folder-check tests passed (11 cases).
6/6 fixture tests passed.
All smoke path checks passed (7 cases).
```

</details>


<details><summary><h3>🦭 Seal report — 2026/04/24 11:07</h3></summary>

## Final Report

### Status: PASS

### Success criteria

- ✓ SC1: `intent-merge check <folder>` discovers all immediate subdirectories with valid plan+build pairs and runs a check on each — verified: `runFolderCheck` scans `readdir` for immediate subdirs, calls `findPlanBuildPair` on each, and `comparePlanBuild` per pair. Live test: `check fixtures/` correctly surfaces all 6 fixture subfolders.
- ✓ SC2: Output labels each pair by subfolder name and reports its result — verified: `presentFolderResults` prints `bold(folder) — status "title"` for each pair; mismatch summaries and insufficient-signal hint appended per pair.
- ✓ SC3: Exit code is non-zero if any pair is off spec or has insufficient signal — verified: `folderCheckHasFailure` returns true for any `kind !== "aligned"`, sets `process.exitCode = 1`. Tested: mixed fixture folder exits 1, all-aligned exits 0.
- ✓ SC4: `--json` mode emits array of result objects with `folder`, `kind`, `title`, `mismatches` fields; exits 1 if any pair not aligned — verified: live `check fixtures/ --json` produces valid JSON array with all 4 fields; exit 1 confirmed.
- ✓ SC5: Empty folder (no pairs) prints same friendly error message as single-pair mode — verified: both paths emit identical "No markdown spec + implementation pair found..." text. Test 8 confirms.
- ✓ SC6: Existing single-pair behavior (folder with plan+build at root) unchanged — verified: `check fixtures/01-aligned` → "On spec", exit 0. Root pair wins even with mismatching subfolders (Test 11).
- ✓ SC7: Tests cover all-aligned, mixed-result, empty folder, and single-root-pair — verified: `scripts/test-folder-check.mjs` has 11 cases covering all four scenarios at both unit and CLI level. All pass.

### Agent decisions to review

- **`insufficient_signal` exit code scope** (documented in PR): folder-mode exits 1 on `insufficient_signal`; no-arg single-pair mode (pre-existing) exits 0. This deliberate divergence preserves backward compatibility (AC6). Acceptable and explicitly called out in the PR. No drift.
- **`--json` single-root returns array**: Consistent with multi-mode contract; callers always get an array regardless of mode. Good call.

### Integration notes

`folder-check.ts`'s `DEFAULT_BUILDS` list includes `.js` variants (`["build.ts", "index.ts", "build.js", "index.js"]`) while `cli.ts`'s single-pair fallback only checks `["build.ts", "index.ts"]`. This means folder-mode can discover compiled/JS-first build files that single-pair mode cannot, and the error message displayed to users in single-pair mode ("looks for one of: build.ts, index.ts") is narrower than what folder-mode actually tries. This is a minor inconsistency — not user-visible in any current test scenario — and a code comment has been added to `folder-check.ts` flagging it for future alignment.

### Test results

Full suite: 6 fixture tests passed, 7 smoke path tests passed, 11 folder-check tests passed — 24 total, 0 failed, 0 skipped.

</details>

### 🪼 Pulse metrics

| Phase | Target | Duration | Tokens | Tool uses | Outcome | Date |
| ----- | ------ | -------- | ------ | --------- | ------- | ---- |
| scope | #1 | 3m 12s | — | — | plan created | 2026-04-24 00:03 |
| slice | #1 | 2m02s | 31202 | 22 | No sub-issues needed — plan issue moves directly into implementation | 2026-04-24 10:39 |
| implement | #1 | 7m32s | 63915 | 77 | Implementation complete for folder-first MVP | 2026-04-24 10:50 |
| inspect | #1 | 4m18s | 45018 | 40 | PASS: all 7 acceptance criteria met, 24 tests green | 2026-04-24 10:57 |
| merge | #1 | 2m30s | 20561 | 21 | No parent — forwarding to seal for holistic review | 2026-04-24 11:02 |
| seal | #1 | 7m54s | 52366 | 58 | Seal PASS — all 7 acceptance criteria met, 24 tests green | 2026-04-24 11:11 |
| **Total** | | **27m28s** | **213062** | **218** | | |
<!-- end metrics table -->